### PR TITLE
Inductor pull

### DIFF
--- a/provisio/oneops-admin/pom.xml
+++ b/provisio/oneops-admin/pom.xml
@@ -8,8 +8,30 @@
   </parent>
   <groupId>com.oneops</groupId>
   <artifactId>oneops-admin</artifactId>
+  <dependencies>
+    <dependency>
+      <groupId>com.oneops</groupId>
+      <artifactId>inductor</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
   <build>
     <plugins>
+      <plugin>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>copy-dependencies</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}</outputDirectory>
+              <includeArtifactIds>inductor</includeArtifactIds>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>


### PR DESCRIPTION
Declare inductor as dependency and pull it into the target folder with dep plugin.

This way the reactor automatically has the right build order and we achieve the same result of the jar in the target folder as the replaced PR.

Replacement for https://github.com/oneops/oneops-build-converter/pull/2

Also related to https://github.com/oneops/oneops-admin/pull/198

Please test as desired and merge. We could also drop the version from the jar name but then we would need to change the linked PR (if desired).

