### PR TITLE
Fix for shade version of jar is not overwriting the actual artifact jar.

### DIFF
--- a/pom.xml.template
+++ b/pom.xml.template
@@ -108,10 +108,6 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
           <version>3.0.0</version>
-          <configuration>
-            <outputFile>${basedir}/target/${project.artifactId}.jar</outputFile>
-            <minimizeJar>false</minimizeJar>
-          </configuration>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
Inductor jar fails to launch as shaded version was not overwriting the artifact versioned jar. lets discuss if this is the  ideal .There need to be a related PR for oneops-admin to pick the versioned jar